### PR TITLE
Update Node.js engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": "^20.0.0"
+    "node": ">=18"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Hello!

Right now your tests are crashing with an error due to a Node.js version limitation.

You are trying to run your tests on version 18, but you have a minimum version of 20 specified.